### PR TITLE
Complete trip history and integrate rewards

### DIFF
--- a/models/bookingModels.js
+++ b/models/bookingModels.js
@@ -93,12 +93,17 @@
       passengerId: { type: String }, // From User Service
       status: {
         type: String,
-        enum: ['requested', 'accepted', 'ongoing', 'completed', 'canceled'],
+        // Support both legacy and spec statuses to avoid breaking existing code
+        enum: ['requested', 'accepted', 'ongoing', 'completed', 'canceled', 'started', 'in-progress', 'cancelled'],
         default: 'ongoing',
       },
 
+      // Fare and accounting
       fare: { type: Number },
+      commission: { type: Number },
+      // Keep legacy distance for compatibility and add distanceKm per spec
       distance: { type: Number },
+      distanceKm: { type: Number },
       duration: { type: Number },
       waitingTime: { type: Number },
       vehicleType: { type: String },
@@ -106,6 +111,18 @@
       // Live path points (for distance computation)
       locations: [{ lat: Number, lng: Number, timestamp: Date }],
 
+      // Preferred spec-compliant fields
+      startLocation: {
+        latitude: Number,
+        longitude: Number,
+        address: String,
+      },
+      endLocation: {
+        latitude: Number,
+        longitude: Number,
+        address: String,
+      },
+      // Legacy aliases (kept for backward compatibility)
       pickupLocation: {
         latitude: Number,
         longitude: Number,

--- a/models/userModels.js
+++ b/models/userModels.js
@@ -10,7 +10,9 @@ const PassengerSchema = new mongoose.Schema({
   email: { type: String, index: true, unique: true },
   password: { type: String, required: true },
   emergencyContacts: [{ name: String, phone: String }],
-  roles: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Role' }]
+  roles: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Role' }],
+  // Rewards balance stored directly on user to avoid new collections
+  rewardPoints: { type: Number, default: 0 }
 }, { timestamps: true, toJSON: { versionKey: false }, toObject: { versionKey: false } });
 
 PassengerSchema.set('toJSON', {
@@ -45,7 +47,9 @@ const DriverSchema = new mongoose.Schema({
   // Rating information
   rating: { type: Number, default: 5.0, min: 1, max: 5 },
   ratingCount: { type: Number, default: 0 },
-  roles: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Role' }]
+  roles: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Role' }],
+  // Rewards balance stored directly on user to avoid new collections
+  rewardPoints: { type: Number, default: 0 }
 }, { timestamps: true, _id: false, toJSON: { versionKey: false }, toObject: { versionKey: false } });
 
 DriverSchema.set('toJSON', {


### PR DESCRIPTION
Add missing trip details to `TripHistory` schema and integrate reward points into user models and trip completion logic to match spec and avoid new files.

The user requested specific fields for `TripHistory` and a rewards system that reuses existing user models. This PR updates the `TripHistory` schema with the requested fields, adds `rewardPoints` to `Passenger` and `Driver` schemas, and modifies `bookingLifecycleService` to populate these fields and award points upon trip completion.

---
<a href="https://cursor.com/background-agent?bcId=bc-77b2ef77-6548-4753-9a9d-59dc9509954b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77b2ef77-6548-4753-9a9d-59dc9509954b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

